### PR TITLE
Tests: use docker geth instance for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,14 +20,10 @@ before_install:
   - sudo apt-get install software-properties-common
   - sudo add-apt-repository -y ppa:ethereum/ethereum
   - sudo apt-get update
-  - sudo bash tools/setup/install_geth_1_8_3.sh
-  - geth version
 install:
   - npm install
   - npm install -g mocha
-before_script:
-  - node tools/initDevEnv.js ~
 script:
-  - mocha --timeout 120000 test/* --exit
+  - mocha --recursive --timeout 120000 test --exit
 after_script:
   - kill $(ps aux | grep 'openst-setup/origin-geth' | awk '{print $2}')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.10.0
 
+Use docker geth instance for testing ([#58](https://github.com/OpenSTFoundation/brandedtoken.js/pull/58))
 Directory structure improvements ([#54](https://github.com/OpenSTFoundation/brandedtoken.js/pull/54))
 Documentation improvements ([#53](https://github.com/OpenSTFoundation/brandedtoken.js/pull/53))
 Interaction for Staker.requestStake and Facilitator.acceptStakeRequest ([#50](https://github.com/OpenSTFoundation/brandedtoken.js/pull/50))

--- a/lib/helpers/setup/BTHelper.js
+++ b/lib/helpers/setup/BTHelper.js
@@ -74,7 +74,8 @@ class BTHelper {
       conversionRate,
       conversionRateDecimals,
       organization,
-      deployParams
+      deployParams,
+      web3
     );
 
     return promiseChain;
@@ -212,7 +213,7 @@ class BTHelper {
     const bin = abiBinProvider.getBIN(ContractName);
 
     let defaultOptions = {
-      gas: '8000000'
+      gas: '7500000'
     };
 
     if (txOptions) {

--- a/lib/helpers/setup/GCHelper.js
+++ b/lib/helpers/setup/GCHelper.js
@@ -140,7 +140,7 @@ class GCHelper {
     const bin = abiBinProvider.getBIN(ContractName);
 
     let defaultOptions = {
-      gas: '8000000'
+      gas: '7500000'
     };
 
     if (txOptions) {

--- a/lib/helpers/setup/GCHelper.js
+++ b/lib/helpers/setup/GCHelper.js
@@ -52,7 +52,7 @@ class GCHelper {
     brandedToken = config.brandedToken;
 
     // Deploy the Contract
-    let promiseChain = oThis.deploy(owner, valueToken, brandedToken, deployParams);
+    let promiseChain = oThis.deploy(owner, valueToken, brandedToken, deployParams, web3);
 
     return promiseChain;
   }

--- a/lib/helpers/setup/UBTHelper.js
+++ b/lib/helpers/setup/UBTHelper.js
@@ -62,7 +62,8 @@ class UBTHelper {
       config.name,
       config.decimals,
       config.organization,
-      deployParams
+      deployParams,
+      web3
     );
 
     return promiseChain;
@@ -133,7 +134,7 @@ class UBTHelper {
     const bin = abiBinProvider.getBIN(ContractName);
 
     let defaultOptions = {
-      gas: '8000000'
+      gas: '7500000'
     };
 
     if (txOptions) {

--- a/lib/helpers/stake/gateway_composer/StakeHelper.js
+++ b/lib/helpers/stake/gateway_composer/StakeHelper.js
@@ -368,7 +368,7 @@ class StakeHelper {
     let defaultOptions = {
       from: owner,
       to: oThis.gatewayComposer,
-      gas: '8000000'
+      gas: '7500000'
     };
 
     if (txOptions) {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "mocha": "5.0.0",
     "commander": "2.8.1",
     "abi-decoder": "1.2.0",
-    "wait-port": "^0.2.2"
+    "wait-port": "0.2.2"
   },
   "pre-commit": [
     "pre-commit"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "chai": "4.1.2",
     "mocha": "5.0.0",
     "commander": "2.8.1",
-    "abi-decoder": "1.2.0"
+    "abi-decoder": "1.2.0",
+    "wait-port": "^0.2.2"
   },
   "pre-commit": [
     "pre-commit"

--- a/test/integration/helpers/BTHelper.js
+++ b/test/integration/helpers/BTHelper.js
@@ -10,12 +10,12 @@ const Setup = Package.EconomySetup,
   BTHelper = Setup.BrandedTokenHelper,
   assert = chai.assert;
 
+const { dockerSetup, dockerTeardown } = require('../../utils/docker');
+
 const config = require('../../utils/configReader'),
-  Web3WalletHelper = require('../../utils/Web3WalletHelper'),
   KeepAliveConfig = require('../../utils/KeepAliveConfig');
 
-const web3 = new Web3(config.gethRpcEndPoint);
-let web3WalletHelper = new Web3WalletHelper(web3);
+let web3;
 
 // Do not forget to set caBT = null below.
 //ca stands for contract address.
@@ -40,38 +40,47 @@ let validateDeploymentReceipt = (receipt) => {
 const valueTokenTestAddress = '0x1610A6b7656E4A323ffeBfbC7E147F5A2ff9d423';
 
 describe('tests/helpers/BTHelper', function() {
-  let deployParams = {
-    from: config.deployerAddress,
-    gasPrice: config.gasPrice
-  };
+  let deployerAddress;
+  let facilitatorAddress;
+  let deployParams;
 
   let helper = new BTHelper(web3, caBT);
 
-  before(function() {
-    this.timeout(3 * 60000);
-    // This hook could take long time.
-    return web3WalletHelper.init(web3).then(function(_out) {
-      if (!caOrganization) {
-        console.log('* Setting up Organization');
-        let orgHelper = new OrganizationHelper(web3, caOrganization);
-        const orgConfig = {
-          deployer: config.deployerAddress,
-          owner: config.deployerAddress,
-          workers: [config.facilitatorAddress]
-        };
-        return orgHelper.setup(orgConfig).then(function() {
-          caOrganization = orgHelper.address;
-        });
-      }
-      return _out;
-    });
+  before(async function() {
+    // Set up docker geth instance and retrieve RPC endpoint
+    const { rpcEndpointOrigin } = await dockerSetup();
+    web3 = new Web3(rpcEndpointOrigin);
+    const accountsOrigin = await web3.eth.getAccounts();
+    deployerAddress = accountsOrigin[0];
+    facilitatorAddress = accountsOrigin[1];
+    deployParams = {
+      from: deployerAddress,
+      gasPrice: config.gasPrice
+    };
+
+    if (!caOrganization) {
+      console.log('* Setting up Organization');
+      let orgHelper = new OrganizationHelper(web3, caOrganization);
+      const orgConfig = {
+        deployer: deployerAddress,
+        owner: deployerAddress,
+        workers: [facilitatorAddress]
+      };
+      return orgHelper.setup(orgConfig).then(function() {
+        caOrganization = orgHelper.address;
+      });
+    }
+  });
+
+  after(() => {
+    dockerTeardown();
   });
 
   if (!caBT) {
     it('should deploy new BrandedToken contract', function() {
       this.timeout(60000);
       return helper
-        .deploy(valueTokenTestAddress, 'BT', 'MyBrandedToken', 18, 1000, 5, caOrganization, deployParams)
+        .deploy(valueTokenTestAddress, 'BT', 'MyBrandedToken', 18, 1000, 5, caOrganization, deployParams, web3)
         .then(validateDeploymentReceipt)
         .then((receipt) => {
           caBT = receipt.contractAddress;
@@ -83,7 +92,7 @@ describe('tests/helpers/BTHelper', function() {
   it('should setup BrandedToken', function() {
     this.timeout(60000);
     const helperConfig = {
-      deployer: config.deployerAddress,
+      deployer: deployerAddress,
       valueToken: valueTokenTestAddress,
       symbol: 'BT',
       name: 'MyBrandedToken',
@@ -92,13 +101,13 @@ describe('tests/helpers/BTHelper', function() {
       conversionRateDecimals: 5,
       organization: caOrganization
     };
-    return helper.setup(helperConfig, deployParams);
+    return helper.setup(helperConfig, deployParams, web3);
   });
 
   it('should lift restrictions', function() {
     this.timeout(60000);
     return helper
-      .liftRestriction([caOrganization, config.deployerAddress], config.facilitatorAddress)
+      .liftRestriction([caOrganization, deployerAddress], facilitatorAddress, null, null, web3)
       .then(validateReceipt);
   });
 });

--- a/test/integration/helpers/UBTHelper.js
+++ b/test/integration/helpers/UBTHelper.js
@@ -74,6 +74,10 @@ describe('tests/helpers/UBTHelper', function() {
     }
   });
 
+  after(() => {
+    dockerTeardown();
+  });
+
   if (!caUBT) {
     it('should deploy new UtilityBrandedToken contract', function() {
       this.timeout(60000);

--- a/test/integration/helpers/stake/Facilitator.js
+++ b/test/integration/helpers/stake/Facilitator.js
@@ -88,6 +88,10 @@ describe('Facilitator', async function() {
     }
   });
 
+  after(() => {
+    dockerTeardown();
+  });
+
   it('Completes staker.requestStake successfully', async function() {
     this.timeout(4 * 60000);
 

--- a/test/integration/helpers/stake/Facilitator.js
+++ b/test/integration/helpers/stake/Facilitator.js
@@ -10,7 +10,6 @@ const Setup = Package.EconomySetup,
   OrganizationHelper = Setup.OrganizationHelper,
   assert = chai.assert,
   config = require('../../../utils/configReader'),
-  Web3WalletHelper = require('../../../utils/Web3WalletHelper'),
   StakeHelper = require('../../../../lib/helpers/stake/gateway_composer/StakeHelper'),
   Staker = require('../../../../lib/helpers/stake/gateway_composer/Staker'),
   Facilitator = require('../../../../lib/helpers/stake/gateway_composer/Facilitator'),
@@ -20,15 +19,14 @@ const Setup = Package.EconomySetup,
   GCHelper = Setup.GatewayComposerHelper,
   KeepAliveConfig = require('../../../utils/KeepAliveConfig');
 
-const web3 = new Web3(config.gethRpcEndPoint),
-  web3WalletHelper = new Web3WalletHelper(web3),
-  owner = config.deployerAddress;
+const { dockerSetup, dockerTeardown } = require('../../../utils/docker');
 
-let worker,
+let web3,
+  owner,
+  worker,
   caOrganization = null,
   caMockToken,
   caGC,
-  wallets,
   stakeRequestHash,
   gatewayComposerAddress,
   facilitator,
@@ -45,58 +43,56 @@ const valueTokenInWei = '200',
   gasPrice = '8000000',
   gasLimit = '100';
 
-let txOptions = {
-  from: owner,
-  gas: '8000000'
-};
-
 describe('Facilitator', async function() {
-  let deployParams = {
-    from: config.deployerAddress,
-    gasPrice: config.gasPrice
-  };
+  let deployerAddress;
+  let deployParams;
+  let txOptions;
 
-  before(function() {
-    this.timeout(3 * 60000);
+  before(async function() {
+    // Set up docker geth instance and retrieve RPC endpoint
+    const { rpcEndpointOrigin } = await dockerSetup();
+    web3 = new Web3(rpcEndpointOrigin);
+    const accountsOrigin = await web3.eth.getAccounts();
+    deployerAddress = accountsOrigin[0];
+    owner = deployerAddress;
+    deployParams = {
+      from: deployerAddress,
+      gasPrice: config.gasPrice
+    };
 
-    return web3WalletHelper
-      .init(web3)
-      .then(function(_out) {
-        if (!caOrganization) {
-          console.log('* Setting up Organization');
-          wallets = web3WalletHelper.web3Object.eth.accounts.wallet;
-          worker = wallets[1].address;
-          beneficiary = wallets[2].address;
-          facilitator = wallets[3].address;
-          let orgHelper = new OrganizationHelper(web3, caOrganization);
-          const orgConfig = {
-            deployer: config.deployerAddress,
-            owner: owner,
-            workers: worker,
-            workerExpirationHeight: '20000000'
-          };
-          return orgHelper.setup(orgConfig).then(function() {
-            caOrganization = orgHelper.address;
-          });
-        }
-        return _out;
-      })
-      .then(function() {
-        if (!caMockToken) {
-          deployer = new MockContractsDeployer(config.deployerAddress, web3);
-          return deployer.deployMockToken().then(function() {
-            caMockToken = deployer.addresses.MockToken;
-            return caMockToken;
-          });
-        }
+    beneficiary = accountsOrigin[2];
+    facilitator = accountsOrigin[1];
+
+    if (!caOrganization) {
+      console.log('* Setting up Organization');
+      // Create worker address in wallet in order to sign EIP 712 hash
+      await web3.eth.accounts.wallet.create(1);
+      worker = web3.eth.accounts.wallet[0].address;
+
+      let orgHelper = new OrganizationHelper(web3, caOrganization);
+      const orgConfig = {
+        deployer: deployerAddress,
+        owner: owner,
+        workers: worker,
+        workerExpirationHeight: '20000000'
+      };
+      orgHelper.setup(orgConfig).then(function() {
+        caOrganization = orgHelper.address;
       });
+    }
+    if (!caMockToken) {
+      deployer = new MockContractsDeployer(deployerAddress, web3);
+      return deployer.deployMockToken().then(function() {
+        caMockToken = deployer.addresses.MockToken;
+      });
+    }
   });
 
   it('Completes staker.requestStake successfully', async function() {
     this.timeout(4 * 60000);
 
     const helperConfig = {
-      deployer: config.deployerAddress,
+      deployer: deployerAddress,
       valueToken: caMockToken,
       symbol: 'BT',
       name: 'MyBrandedToken',
@@ -106,19 +102,24 @@ describe('Facilitator', async function() {
       organization: caOrganization
     };
 
+    txOptions = {
+      from: owner,
+      gas: '7500000'
+    };
+
     const btHelper = new BTHelper(web3, caBT);
     caBT = await btHelper.setup(helperConfig, deployParams);
     btAddress = caBT.contractAddress;
 
     const gcHelperConfig = {
-      deployer: config.deployerAddress,
+      deployer: deployerAddress,
       valueToken: caMockToken,
       brandedToken: btAddress,
       owner: owner
     };
 
     let gcDeployParams = {
-      from: config.deployerAddress,
+      from: deployerAddress,
       gasPrice: config.gasPrice
     };
 
@@ -171,7 +172,7 @@ describe('Facilitator', async function() {
     const hashLockInstance = Mosaic.Helpers.StakeHelper.createSecretHashLock();
     txOptions = {
       from: facilitator,
-      gas: '8000000'
+      gas: '7500000'
     };
     const gatewayContractInstance = Mosaic.Contracts.getEIP20Gateway(web3, caGateway, txOptions);
     let bountyAmountInWei = await gatewayContractInstance.methods.bounty().call();

--- a/test/integration/helpers/stake/StakeHelper.js
+++ b/test/integration/helpers/stake/StakeHelper.js
@@ -10,7 +10,6 @@ const Setup = Package.EconomySetup,
   OrganizationHelper = Setup.OrganizationHelper,
   assert = chai.assert,
   config = require('../../../utils/configReader'),
-  Web3WalletHelper = require('../../../utils/Web3WalletHelper'),
   StakeHelper = require('../../../../lib/helpers/stake/gateway_composer/StakeHelper'),
   MockContractsDeployer = require('../../../utils/MockContractsDeployer'),
   abiBinProvider = MockContractsDeployer.abiBinProvider(),
@@ -18,15 +17,14 @@ const Setup = Package.EconomySetup,
   GCHelper = Setup.GatewayComposerHelper,
   KeepAliveConfig = require('../../../utils/KeepAliveConfig');
 
-const web3 = new Web3(config.gethRpcEndPoint),
-  web3WalletHelper = new Web3WalletHelper(web3),
-  owner = config.deployerAddress;
+const { dockerSetup, dockerTeardown } = require('../../../utils/docker');
 
-let worker,
+let web3,
+  owner,
+  worker,
   caOrganization = null,
   caMockToken,
   caGC,
-  wallets,
   stakeRequestHash,
   gatewayComposerAddress,
   facilitator,
@@ -40,59 +38,58 @@ let worker,
 
 const valueTokenInWei = '200',
   gasPrice = '8000000',
-  gasLimit = '100',
-  txOptions = {
-    from: owner,
-    gas: '8000000'
-  };
+  gasLimit = '100';
 
 describe('StakeHelper', async function() {
-  let deployParams = {
-    from: config.deployerAddress,
-    gasPrice: config.gasPrice
-  };
+  let deployerAddress;
+  let deployParams;
+  let txOptions;
 
-  before(function() {
-    this.timeout(3 * 60000);
-    //This hook could take long time.
-    return web3WalletHelper
-      .init(web3)
-      .then(function(_out) {
-        if (!caOrganization) {
-          console.log('* Setting up Organization');
-          wallets = web3WalletHelper.web3Object.eth.accounts.wallet;
-          worker = wallets[1].address;
-          beneficiary = wallets[2].address;
-          facilitator = wallets[3].address;
-          let orgHelper = new OrganizationHelper(web3, caOrganization);
-          const orgConfig = {
-            deployer: config.deployerAddress,
-            owner: owner,
-            workers: worker,
-            workerExpirationHeight: '20000000'
-          };
-          return orgHelper.setup(orgConfig).then(function() {
-            caOrganization = orgHelper.address;
-          });
-        }
-        return _out;
-      })
-      .then(function() {
-        if (!caMockToken) {
-          deployer = new MockContractsDeployer(config.deployerAddress, web3);
-          return deployer.deployMockToken().then(function() {
-            caMockToken = deployer.addresses.MockToken;
-            return caMockToken;
-          });
-        }
+  before(async function() {
+    // Set up docker geth instance and retrieve RPC endpoint
+    const { rpcEndpointOrigin } = await dockerSetup();
+    web3 = new Web3(rpcEndpointOrigin);
+    const accountsOrigin = await web3.eth.getAccounts();
+    deployerAddress = accountsOrigin[0];
+    owner = deployerAddress;
+    deployParams = {
+      from: deployerAddress,
+      gasPrice: config.gasPrice
+    };
+
+    beneficiary = accountsOrigin[2];
+    facilitator = accountsOrigin[1];
+
+    if (!caOrganization) {
+      console.log('* Setting up Organization');
+      // Create worker address in wallet in order to sign EIP 712 hash
+      await web3.eth.accounts.wallet.create(1);
+      worker = web3.eth.accounts.wallet[0].address;
+
+      let orgHelper = new OrganizationHelper(web3, caOrganization);
+      const orgConfig = {
+        deployer: deployerAddress,
+        owner: owner,
+        workers: worker,
+        workerExpirationHeight: '20000000'
+      };
+      orgHelper.setup(orgConfig).then(function() {
+        caOrganization = orgHelper.address;
       });
+    }
+    if (!caMockToken) {
+      deployer = new MockContractsDeployer(deployerAddress, web3);
+      return deployer.deployMockToken().then(function() {
+        caMockToken = deployer.addresses.MockToken;
+      });
+    }
   });
 
   it('Should perform requestStake successfully', async function() {
     this.timeout(4 * 60000);
 
     const helperConfig = {
-      deployer: config.deployerAddress,
+      deployer: deployerAddress,
       valueToken: caMockToken,
       symbol: 'BT',
       name: 'MyBrandedToken',
@@ -102,19 +99,24 @@ describe('StakeHelper', async function() {
       organization: caOrganization
     };
 
+    txOptions = {
+      from: owner,
+      gas: '7500000'
+    };
+
     const btHelper = new BTHelper(web3, caBT);
     caBT = await btHelper.setup(helperConfig, deployParams);
     btAddress = caBT.contractAddress;
 
     const gcHelperConfig = {
-      deployer: config.deployerAddress,
+      deployer: deployerAddress,
       valueToken: caMockToken,
       brandedToken: btAddress,
       owner: owner
     };
 
     let gcDeployParams = {
-      from: config.deployerAddress,
+      from: deployerAddress,
       gasPrice: config.gasPrice
     };
 

--- a/test/integration/helpers/stake/StakeHelper.js
+++ b/test/integration/helpers/stake/StakeHelper.js
@@ -85,6 +85,10 @@ describe('StakeHelper', async function() {
     }
   });
 
+  after(() => {
+    dockerTeardown();
+  });
+
   it('Should perform requestStake successfully', async function() {
     this.timeout(4 * 60000);
 

--- a/test/integration/helpers/stake/Staker.js
+++ b/test/integration/helpers/stake/Staker.js
@@ -84,6 +84,10 @@ describe('Staker', async function() {
     }
   });
 
+  after(() => {
+    dockerTeardown();
+  });
+
   it('Completes staker.requestStake successfully', async function() {
     this.timeout(4 * 60000);
 

--- a/test/integration/helpers/stake/Staker.js
+++ b/test/integration/helpers/stake/Staker.js
@@ -9,7 +9,6 @@ const Setup = Package.EconomySetup,
   OrganizationHelper = Setup.OrganizationHelper,
   assert = chai.assert,
   config = require('../../../utils/configReader'),
-  Web3WalletHelper = require('../../../utils/Web3WalletHelper'),
   StakeHelper = require('../../../../lib/helpers/stake/gateway_composer/StakeHelper'),
   Staker = require('../../../../lib/helpers/stake/gateway_composer/Staker'),
   MockContractsDeployer = require('../../../utils/MockContractsDeployer'),
@@ -18,15 +17,14 @@ const Setup = Package.EconomySetup,
   GCHelper = Setup.GatewayComposerHelper,
   KeepAliveConfig = require('../../../utils/KeepAliveConfig');
 
-const web3 = new Web3(config.gethRpcEndPoint),
-  web3WalletHelper = new Web3WalletHelper(web3),
-  owner = config.deployerAddress;
+const { dockerSetup, dockerTeardown } = require('../../../utils/docker');
 
-let worker,
+let web3,
+  owner,
+  worker,
   caOrganization = null,
   caMockToken,
   caGC,
-  wallets,
   stakeRequestHash,
   gatewayComposerAddress,
   facilitator,
@@ -39,59 +37,58 @@ let worker,
 
 const valueTokenInWei = '200',
   gasPrice = '8000000',
-  gasLimit = '100',
-  txOptions = {
-    from: owner,
-    gas: '8000000'
-  };
+  gasLimit = '100';
 
 describe('Staker', async function() {
-  let deployParams = {
-    from: config.deployerAddress,
-    gasPrice: config.gasPrice
-  };
+  let deployerAddress;
+  let deployParams;
+  let txOptions;
 
-  before(function() {
-    this.timeout(3 * 60000);
+  before(async function() {
+    // Set up docker geth instance and retrieve RPC endpoint
+    const { rpcEndpointOrigin } = await dockerSetup();
+    web3 = new Web3(rpcEndpointOrigin);
+    const accountsOrigin = await web3.eth.getAccounts();
+    deployerAddress = accountsOrigin[0];
+    owner = deployerAddress;
+    deployParams = {
+      from: deployerAddress,
+      gasPrice: config.gasPrice
+    };
 
-    return web3WalletHelper
-      .init(web3)
-      .then(function(_out) {
-        if (!caOrganization) {
-          console.log('* Setting up Organization');
-          wallets = web3WalletHelper.web3Object.eth.accounts.wallet;
-          worker = wallets[1].address;
-          beneficiary = wallets[2].address;
-          facilitator = wallets[3].address;
-          let orgHelper = new OrganizationHelper(web3, caOrganization);
-          const orgConfig = {
-            deployer: config.deployerAddress,
-            owner: owner,
-            workers: worker,
-            workerExpirationHeight: '20000000'
-          };
-          return orgHelper.setup(orgConfig).then(function() {
-            caOrganization = orgHelper.address;
-          });
-        }
-        return _out;
-      })
-      .then(function() {
-        if (!caMockToken) {
-          deployer = new MockContractsDeployer(config.deployerAddress, web3);
-          return deployer.deployMockToken().then(function() {
-            caMockToken = deployer.addresses.MockToken;
-            return caMockToken;
-          });
-        }
+    beneficiary = accountsOrigin[2];
+    facilitator = accountsOrigin[1];
+
+    if (!caOrganization) {
+      console.log('* Setting up Organization');
+      // Create worker address in wallet in order to sign EIP 712 hash
+      await web3.eth.accounts.wallet.create(1);
+      worker = web3.eth.accounts.wallet[0].address;
+
+      let orgHelper = new OrganizationHelper(web3, caOrganization);
+      const orgConfig = {
+        deployer: deployerAddress,
+        owner: owner,
+        workers: worker,
+        workerExpirationHeight: '20000000'
+      };
+      orgHelper.setup(orgConfig).then(function() {
+        caOrganization = orgHelper.address;
       });
+    }
+    if (!caMockToken) {
+      deployer = new MockContractsDeployer(deployerAddress, web3);
+      return deployer.deployMockToken().then(function() {
+        caMockToken = deployer.addresses.MockToken;
+      });
+    }
   });
 
   it('Completes staker.requestStake successfully', async function() {
     this.timeout(4 * 60000);
 
     const helperConfig = {
-      deployer: config.deployerAddress,
+      deployer: deployerAddress,
       valueToken: caMockToken,
       symbol: 'BT',
       name: 'MyBrandedToken',
@@ -101,19 +98,24 @@ describe('Staker', async function() {
       organization: caOrganization
     };
 
+    txOptions = {
+      from: owner,
+      gas: '7500000'
+    };
+
     const btHelper = new BTHelper(web3, caBT);
     caBT = await btHelper.setup(helperConfig, deployParams);
     btAddress = caBT.contractAddress;
 
     const gcHelperConfig = {
-      deployer: config.deployerAddress,
+      deployer: deployerAddress,
       valueToken: caMockToken,
       brandedToken: btAddress,
       owner: owner
     };
 
     let gcDeployParams = {
-      from: config.deployerAddress,
+      from: deployerAddress,
       gasPrice: config.gasPrice
     };
 

--- a/test/utils/configReader.js
+++ b/test/utils/configReader.js
@@ -1,23 +1,10 @@
 'use strict';
 
-const testHelper = require('./helper');
-
-let devEnvConfig = require(testHelper.configFilePath);
 const ConfigReader = function() {};
 
 ConfigReader.prototype = {
-  deployerAddress: devEnvConfig.deployerAddress,
-  chainOwner: devEnvConfig.chainOwnerAddress,
-  organizationOwner: devEnvConfig.organizationAddress,
-  organizationAdmin: devEnvConfig.wallet1,
-  organizationWorker: devEnvConfig.facilitator,
-  wallet1: devEnvConfig.wallet1,
-  wallet2: devEnvConfig.wallet2,
-  facilitatorAddress: devEnvConfig.facilitator,
-  gethRpcEndPoint: devEnvConfig.gethRpcEndPoint,
-  passphrase: 'testtest',
   gasPrice: '0x3B9ACA00',
-  gas: 8000000,
+  gas: 7500000,
   nullBytes32: '0x0000000000000000000000000000000000000000000000000000000000000000'
 };
 

--- a/test/utils/configReader.js
+++ b/test/utils/configReader.js
@@ -5,7 +5,8 @@ const ConfigReader = function() {};
 ConfigReader.prototype = {
   gasPrice: '0x3B9ACA00',
   gas: 7500000,
-  nullBytes32: '0x0000000000000000000000000000000000000000000000000000000000000000'
+  nullBytes32: '0x0000000000000000000000000000000000000000000000000000000000000000',
+  originPort: 8546
 };
 
 module.exports = new ConfigReader();

--- a/test/utils/docker-compose.yml
+++ b/test/utils/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3"
+
+services:
+
+  geth_node_origin:
+    image: augurproject/dev-node-geth:v1.8.18
+    ports:
+      - "8546:8545"

--- a/test/utils/docker.js
+++ b/test/utils/docker.js
@@ -1,0 +1,48 @@
+const childProcess = require('child_process');
+const path = require('path');
+const waitPort = require('wait-port');
+
+const composeFilePath = path.join(__dirname, './docker-compose.yml');
+
+const asyncSleep = (ms) => {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+};
+
+const dockerSetup = () => {
+  const dockerCompose = childProcess.spawn('docker-compose', ['-f', composeFilePath, 'up', '--force-recreate']);
+
+  if (process.env.TEST_STDOUT) {
+    dockerCompose.stdout.on('data', (data) => {
+      process.stdout.write(data);
+    });
+    dockerCompose.stderr.on('data', (data) => {
+      process.stderr.write(data);
+    });
+  }
+
+  const originPort = 8546;
+
+  const waitForOriginNode = waitPort({ port: originPort, output: 'silent' });
+  return Promise.all([waitForOriginNode])
+    .then(() => {
+      // even after the port is available, the node needs a bit of time to get online
+      return asyncSleep(5000);
+    })
+    .then(() => ({
+      rpcEndpointOrigin: `http://localhost:${originPort}`
+    }));
+};
+
+const dockerTeardown = () => {
+  const dockerComposeDown = childProcess.spawnSync('docker-compose', ['-f', composeFilePath, 'down']);
+  if (process.env.TEST_STDOUT) {
+    process.stdout.write(dockerComposeDown.stdout);
+    process.stderr.write(dockerComposeDown.stderr);
+  }
+};
+
+module.exports = {
+  asyncSleep,
+  dockerSetup,
+  dockerTeardown
+};


### PR DESCRIPTION
This PR enables using a geth instance provided via docker and updates tests to use that web3 provider.

The docker geth funds several addresses, but only unlocks 3. See https://github.com/AugurProject/ethereum-nodes/blob/master/geth-poa/genesis.json.

The `worker` who signs in a given test is an address that is created via `web3.eth.accounts.wallet.create`.

✏️ N.B.: files that may no longer be necessary (e.g., `Web3WalletHelper.js`) have been left in place, to be on the safe side.
✏️ N.B.: as I am not skilled in promise-handling, please review areas of such adjustment especially carefully.

Resolves #27.