### PR TITLE
Remove explicit node/npm installation steps in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,6 @@ notifications:
     on_failure: always
 node_js:
   - "9"
-before_install:
-  - sudo apt-get update
-  - sudo apt-get install nodejs
-  - sudo apt-get install npm
 install:
   - npm install
   - npm install -g mocha


### PR DESCRIPTION
This removes the explicit installation steps for node/npm in TravisCI.

We are already specifying node version 9 via the `node_js` property in the `.travis.yml`, which Travis manages via `NVM`.

By then installing `node` and `npm` via the Ubuntu package manager we also install the latest version available from the package manager, which could potentially lead to that version being used in the build instead of the one specified in `.travis.yml`, and also spends unnecessary time during the Travis build for installation.