### PR TITLE
Remove redundant parameters from Facilitator

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -264,14 +264,16 @@ const gatewayContractInstance = new Mosaic.ContractInteract.EIP20Gateway(web3Pro
 const stake = async () => {
   const bountyAmountInWei = await gatewayContractInstance.getBounty();
 
+  const stakeHelper = new StakeHelper(web3Provider, brandedTokenAddress, gatewayComposerAddress);
+  const abiBinProvider = new AbiBinProvider();
+
   const Facilitator = BrandedToken.Helpers.Facilitator;
   const facilitatorInstance = new Facilitator(
     web3Provider,
     eip20Token,
-    brandedTokenAddress,
-    gatewayComposerAddress,
     facilitator,
-    new AbiBinProvider(),
+    stakeHelper,
+    abiBinProvider,
   );
 
   txOptions = {

--- a/README.MD
+++ b/README.MD
@@ -256,30 +256,42 @@ const signature = workerAccount.signEIP712TypedData(stakeRequestTypedData);
 ### Facilitator calls acceptStakeRequest
 
 ```js
+const { AbiBinProvider } = BrandedToken;
+const Mosaic = require('@openstfoundation/mosaic.js');
 const hashLockInstance = Mosaic.Utils.createSecretHashLock();
 const gatewayContractInstance = new Mosaic.ContractInteract.EIP20Gateway(web3Provider, gatewayAddress);
-let bountyAmountInWei;
-gatewayContractInstance.getBounty().then(function(result){
-  bountyAmountInWei = result;
-});
-const Facilitator = BrandedToken.Helpers.Facilitator;
-const facilitatorInstance = new Facilitator(web3Provider, eip20Token, brandedTokenAddress, gatewayComposerAddress, facilitator);
-txOptions = {
-  from: facilitator,
-  gas: '7500000'
-};    
-let stakeRequestHash; // stakeRequestHash unique per stake request stored in GatewayComposer.stakeRequests mapping
-facilitatorInstance.acceptStakeRequest(
-  stakeRequestHash,
-  signature,
-  bountyAmountInWei,
-  eip20TokenAbi,
-  hashLockInstance.hashLock,
-  web3Provider,
-  txOptions
-).then(function(){
-  console.log("Successfully completed acceptStakeRequest!");
-})
+
+const stake = async () => {
+  const bountyAmountInWei = await gatewayContractInstance.getBounty();
+
+  const Facilitator = BrandedToken.Helpers.Facilitator;
+  const facilitatorInstance = new Facilitator(
+    web3Provider,
+    eip20Token,
+    brandedTokenAddress,
+    gatewayComposerAddress,
+    facilitator,
+    new AbiBinProvider(),
+  );
+
+  txOptions = {
+    from: facilitator,
+    gas: '7500000'
+  };
+
+  let stakeRequestHash; // stakeRequestHash unique per stake request stored in GatewayComposer.stakeRequests mapping
+  facilitatorInstance.acceptStakeRequest(
+    stakeRequestHash,
+    signature,
+    bountyAmountInWei,
+    hashLockInstance.hashLock,
+    txOptions
+  ).then(() => {
+    console.log("Successfully completed acceptStakeRequest!");
+  });
+};
+
+stake();
 ```
 
 ## Tests

--- a/contracts/abi/EIP20Token.abi
+++ b/contracts/abi/EIP20Token.abi
@@ -1,0 +1,240 @@
+[
+    {
+        "constant": true,
+        "inputs": [],
+        "name": "name",
+        "outputs": [
+            {
+                "name": "tokenName_",
+                "type": "string"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "constant": false,
+        "inputs": [
+            {
+                "name": "_spender",
+                "type": "address"
+            },
+            {
+                "name": "_value",
+                "type": "uint256"
+            }
+        ],
+        "name": "approve",
+        "outputs": [
+            {
+                "name": "success_",
+                "type": "bool"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "constant": true,
+        "inputs": [],
+        "name": "totalSupply",
+        "outputs": [
+            {
+                "name": "totalTokenSupply_",
+                "type": "uint256"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "constant": false,
+        "inputs": [
+            {
+                "name": "_from",
+                "type": "address"
+            },
+            {
+                "name": "_to",
+                "type": "address"
+            },
+            {
+                "name": "_value",
+                "type": "uint256"
+            }
+        ],
+        "name": "transferFrom",
+        "outputs": [
+            {
+                "name": "success_",
+                "type": "bool"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "constant": true,
+        "inputs": [],
+        "name": "decimals",
+        "outputs": [
+            {
+                "name": "tokenDecimals_",
+                "type": "uint8"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "constant": true,
+        "inputs": [
+            {
+                "name": "_owner",
+                "type": "address"
+            }
+        ],
+        "name": "balanceOf",
+        "outputs": [
+            {
+                "name": "balance_",
+                "type": "uint256"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "constant": true,
+        "inputs": [],
+        "name": "symbol",
+        "outputs": [
+            {
+                "name": "tokenSymbol_",
+                "type": "string"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "constant": false,
+        "inputs": [
+            {
+                "name": "_to",
+                "type": "address"
+            },
+            {
+                "name": "_value",
+                "type": "uint256"
+            }
+        ],
+        "name": "transfer",
+        "outputs": [
+            {
+                "name": "success_",
+                "type": "bool"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "constant": true,
+        "inputs": [
+            {
+                "name": "_owner",
+                "type": "address"
+            },
+            {
+                "name": "_spender",
+                "type": "address"
+            }
+        ],
+        "name": "allowance",
+        "outputs": [
+            {
+                "name": "allowance_",
+                "type": "uint256"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "name": "_symbol",
+                "type": "string"
+            },
+            {
+                "name": "_name",
+                "type": "string"
+            },
+            {
+                "name": "_totalSupply",
+                "type": "uint256"
+            },
+            {
+                "name": "_decimals",
+                "type": "uint8"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "name": "_from",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "name": "_to",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "name": "_value",
+                "type": "uint256"
+            }
+        ],
+        "name": "Transfer",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "name": "_owner",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "name": "_spender",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "name": "_value",
+                "type": "uint256"
+            }
+        ],
+        "name": "Approval",
+        "type": "event"
+    }
+]

--- a/index.js
+++ b/index.js
@@ -30,9 +30,9 @@ const Staker = require('./lib/helpers/stake/gateway_composer/Staker');
 const Facilitator = require('./lib/helpers/stake/gateway_composer/Facilitator');
 
 module.exports = {
-  AbiBinProvider: AbiBinProvider,
-  EconomySetup: EconomySetup,
-  Contracts: Contracts,
+  AbiBinProvider,
+  EconomySetup,
+  Contracts,
   Helpers: {
     StakeHelper: StakeHelper,
     Staker: Staker,

--- a/lib/helpers/stake/gateway_composer/Facilitator.js
+++ b/lib/helpers/stake/gateway_composer/Facilitator.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const StakeHelper = require('./StakeHelper');
-
 /**
  * Facilitator performs below tasks:
  * - approves bounty amount to GatewayComposer
@@ -13,24 +11,21 @@ class Facilitator {
    *
    * @param {Web3} originWeb3 Origin chain web3 address.
    * @param {string} valueToken Value token contract address.
-   * @param {string} brandedToken Branded Token contract address.
-   * @param {string} gatewayComposer Gateway composer contract address.
    * @param {string} facilitator Facilitator address.
+   * @param {StakeHelper} stakeHelper Instance of a stake helper.
    * @param {BtAbiBinProvider} abiBinProvider A class that provides ABIs and BINs.
    */
   constructor(
     originWeb3,
     valueToken,
-    brandedToken,
-    gatewayComposer,
     facilitator,
+    stakeHelper,
     abiBinProvider,
   ) {
     this.originWeb3 = originWeb3;
     this.valueToken = valueToken;
-    this.gatewayComposer = gatewayComposer;
-    this.brandedToken = brandedToken;
     this.facilitator = facilitator;
+    this.stakeHelper = stakeHelper;
     this.abiBinProvider = abiBinProvider;
 
     this.acceptStakeRequest = this.acceptStakeRequest.bind(this);
@@ -61,15 +56,9 @@ class Facilitator {
     hashLock,
     txOptions,
   ) {
-    const stakeHelperInstance = new StakeHelper(
-      this.originWeb3,
-      this.brandedToken,
-      this.gatewayComposer,
-    );
-
     const valueTokenAbi = this.abiBinProvider.getABI('EIP20Token');
 
-    const approveForBountyResult = await stakeHelperInstance.approveForBounty(
+    const approveForBountyResult = await this.stakeHelper.approveForBounty(
       this.facilitator,
       bountyInWei,
       this.valueToken,
@@ -78,7 +67,7 @@ class Facilitator {
     );
     console.log('approveForBounty status:', approveForBountyResult.status);
 
-    const acceptStakeRequestResult = await stakeHelperInstance.acceptStakeRequest(
+    const acceptStakeRequestResult = await this.stakeHelper.acceptStakeRequest(
       stakeRequestHash,
       signature,
       this.facilitator,

--- a/lib/helpers/stake/gateway_composer/Facilitator.js
+++ b/lib/helpers/stake/gateway_composer/Facilitator.js
@@ -1,23 +1,3 @@
-// Copyright 2019 OpenST Ltd.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// ----------------------------------------------------------------------------
-//
-// http://www.simpletoken.org/
-//
-// ----------------------------------------------------------------------------
-
 'use strict';
 
 const StakeHelper = require('./StakeHelper');
@@ -31,20 +11,29 @@ class Facilitator {
   /**
    * Facilitator constructor object.
    *
-   * @param originWeb3 Origin chain web3 address.
-   * @param valueToken Value token contract address.
-   * @param brandedToken Branded Token contract address.
-   * @param gatewayComposer Gateway composer contract address.
-   * @param facilitator Facilitator address.
+   * @param {Web3} originWeb3 Origin chain web3 address.
+   * @param {string} valueToken Value token contract address.
+   * @param {string} brandedToken Branded Token contract address.
+   * @param {string} gatewayComposer Gateway composer contract address.
+   * @param {string} facilitator Facilitator address.
+   * @param {BtAbiBinProvider} abiBinProvider A class that provides ABIs and BINs.
    */
-  constructor(originWeb3, valueToken, brandedToken, gatewayComposer, facilitator) {
-    const oThis = this;
+  constructor(
+    originWeb3,
+    valueToken,
+    brandedToken,
+    gatewayComposer,
+    facilitator,
+    abiBinProvider,
+  ) {
+    this.originWeb3 = originWeb3;
+    this.valueToken = valueToken;
+    this.gatewayComposer = gatewayComposer;
+    this.brandedToken = brandedToken;
+    this.facilitator = facilitator;
+    this.abiBinProvider = abiBinProvider;
 
-    oThis.originWeb3 = originWeb3;
-    oThis.valueToken = valueToken;
-    oThis.gatewayComposer = gatewayComposer;
-    oThis.brandedToken = brandedToken;
-    oThis.facilitator = facilitator;
+    this.acceptStakeRequest = this.acceptStakeRequest.bind(this);
   }
 
   /**
@@ -54,52 +43,47 @@ class Facilitator {
    *
    * Note: Add KYC worker account/private key in web3 wallet before calling acceptStakeRequest.
    *
-   * @param stakeRequestHash Stake request hash unique for each stake.
-   * @param signature Signature object format:
-   *                  {
-   *                    messageHash: signHash,
-   *                    v: vrs[0],
-   *                    r: vrs[1],
-   *                    s: vrs[2],
-   *                    signature: signature
-   *                  }
-   * @param bountyInWei Bounty amount in wei's that needs to be approved.
-   * @param valueTokenAbi ValueToken contract ABI.
-   * @param hashLock HashLock of facilitator.
-   * @param originWeb3 Origin chain web3 object.
-   * @param txOptions - Tx options.
+   * @param {string} stakeRequestHash Stake request hash unique for each stake.
+   * @param {Object} signature Signature object format:
+   * @param {string} signature.messageHash The hash of the signed message.
+   * @param {string} signature.v V of the signature.
+   * @param {string} signature.r R of the signature.
+   * @param {string} signature.s S of the signature.
+   * @param {string} signature.signature Signature.
+   * @param {string} bountyInWei Bounty amount in wei's that needs to be approved.
+   * @param {string} hashLock Hashed secret of facilitator.
+   * @param {Object} txOptions Transaction options used with web3.
    */
   async acceptStakeRequest(
     stakeRequestHash,
     signature,
     bountyInWei,
-    valueTokenAbi,
     hashLock,
-    originWeb3,
     txOptions,
   ) {
-    const oThis = this;
-
     const stakeHelperInstance = new StakeHelper(
-      oThis.originWeb3,
-      oThis.brandedToken,
-      oThis.gatewayComposer,
+      this.originWeb3,
+      this.brandedToken,
+      this.gatewayComposer,
     );
+
+    const valueTokenAbi = this.abiBinProvider.getABI('EIP20Token');
+
     const approveForBountyResult = await stakeHelperInstance.approveForBounty(
-      oThis.facilitator,
+      this.facilitator,
       bountyInWei,
-      oThis.valueToken,
+      this.valueToken,
       valueTokenAbi,
-      originWeb3,
+      this.originWeb3,
     );
     console.log('approveForBounty status:', approveForBountyResult.status);
 
     const acceptStakeRequestResult = await stakeHelperInstance.acceptStakeRequest(
       stakeRequestHash,
       signature,
-      oThis.facilitator,
+      this.facilitator,
       hashLock,
-      oThis.originWeb3,
+      this.originWeb3,
       txOptions,
     );
     console.log('acceptStakeRequest status:', acceptStakeRequestResult.status);

--- a/test/integration/GatewayComposer/BrandedTokenStake.js
+++ b/test/integration/GatewayComposer/BrandedTokenStake.js
@@ -1,23 +1,3 @@
-// Copyright 2019 OpenST Ltd.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// ----------------------------------------------------------------------------
-//
-// http://www.simpletoken.org/
-//
-// ----------------------------------------------------------------------------
-
 'use strict';
 
 // Load external packages
@@ -234,13 +214,15 @@ describe('Performs BrandedToken staking through GatewayComposer', async () => {
     const gatewayContractInstance = new Mosaic.ContractInteract.EIP20Gateway(originWeb3, caGateway);
     const bountyAmountInWei = await gatewayContractInstance.getBounty();
 
+
+    const stakeHelper = new StakeHelper(originWeb3, btAddress, gatewayComposerAddress);
+    const abiBinProviderFacilitator = new AbiBinProvider();
     const facilitatorInstance = new Facilitator(
       originWeb3,
       caMockToken,
-      btAddress,
-      gatewayComposerAddress,
       facilitator,
-      new AbiBinProvider(),
+      stakeHelper,
+      abiBinProviderFacilitator,
     );
     await facilitatorInstance.acceptStakeRequest(
       stakeRequestHash,

--- a/test/integration/GatewayComposer/BrandedTokenStake.js
+++ b/test/integration/GatewayComposer/BrandedTokenStake.js
@@ -22,18 +22,20 @@
 
 // Load external packages
 const BN = require('bn.js');
-const chai = require('chai');
+const { assert } = require('chai');
 const Web3 = require('web3');
 const Mosaic = require('@openstfoundation/mosaic.js');
 const Package = require('./../../../index');
 
+const { AbiBinProvider } = Package;
 const Setup = Package.EconomySetup;
-const { assert } = chai;
 const config = require('./../../utils/configReader');
 
-const { StakeHelper } = Package.Helpers;
-const { Staker } = Package.Helpers;
-const { Facilitator } = Package.Helpers;
+const {
+  StakeHelper,
+  Staker,
+  Facilitator,
+} = Package.Helpers;
 const MockContractsDeployer = require('./../../utils/MockContractsDeployer');
 
 const abiBinProvider = MockContractsDeployer.abiBinProvider();
@@ -238,14 +240,13 @@ describe('Performs BrandedToken staking through GatewayComposer', async () => {
       btAddress,
       gatewayComposerAddress,
       facilitator,
+      new AbiBinProvider(),
     );
     await facilitatorInstance.acceptStakeRequest(
       stakeRequestHash,
       signature,
       bountyAmountInWei,
-      mockTokenAbi,
       hashLockInstance.hashLock,
-      originWeb3,
       txOptions,
     );
 


### PR DESCRIPTION
I updated the Facilitator's constructor and method to exclude
unnecessary arguments.

The AbiBinProvider is now injected into the Facilitator so that the
Facilitator can provide the ABI to the StakeHelper. A longer, proper fix
outside of the scope of this issue would be to update the StakeHelper to
not require the ABI.

I updated the README. If I understood the example correctly, there was a
racing condition for the bounty amount which I fixed by adding `await`
inside an `async` function.

It was not possible to inject the stake helper instead of instantiating
it inside the Facilitator. Redundant data is carried over too far and
fixing the StakeHelper is not in the scope of this issue.

Fixes #89